### PR TITLE
Add support for a local settings file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ results
 logs
 *.logs
 venv
+
+# Local settings
+local_settings.py

--- a/todolist/settings.py
+++ b/todolist/settings.py
@@ -116,3 +116,9 @@ TEMPLATES = [
         },
     },
 ]
+
+
+try:
+    from .local_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
Now we can create a local_settings.py file to manage different environments. Ex: In dev, we will have ALLOWED_HOSTS = ["*"]. In the prod however, we would like to restrict it a bit. This file allows for such changes without affecting git status.

This pull request supports a local settings concept by allowing the developer to create  `todolist/local_settings.py` file which is ignored from git. This file can be used to specify different settings for different environments without worrying about git status getting overloaded.

<br/>

example usage (development environment):
```python
# Filename: todolist/local_settings.py
ALLOWED_HOSTS = ["*"]
DEBUG = True
```

<br/>

example usage (production environment):
```python
# Filename: todolist/local_settings.py
ALLOWED_HOSTS = ["host1", "host2", ... ]
DEBUG = False
```

I know that for this particular project, dev and prod environments are not really a thing but I like using these separate files to make my time easier and thought why not create a pull request for it.